### PR TITLE
Update deprecated actions.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,14 +53,14 @@ jobs:
           pip install poetry
           poetry build -f wheel -vvv
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: PythonLogging
           path: src/py_mel_logging/dlls
           retention-days: 7
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: py-mel-logging-wheel
           path: dist/py_mel_logging-0.2.dev1-py3-none-any.whl
@@ -85,7 +85,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: py-mel-logging-wheel
 
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: PythonLogging
           path: dlls/
@@ -137,14 +137,14 @@ jobs:
 #          poetry run make -C doc latexpdf
 
       - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Documentation-html
           path: doc/build/html
           retention-days: 7
 
 #      - name: Upload PDF Documentation
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: Documentation-pdf
 #          path: doc/build/latex/*.pdf
@@ -171,15 +171,15 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: py-mel-logging-wheel
 
-#      - uses: actions/download-artifact@v2
+#      - uses: actions/download-artifact@v4
 #        with:
 #          name: Documentation-pdf
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: Documentation-html
           path: ~/html


### PR DESCRIPTION
Upload and download artifact actions v3 and earlier are deprecated and no longer work.